### PR TITLE
유저 Not found -> Unauthorization 에러로 변경 #61

### DIFF
--- a/src/main/java/com/seniors/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/seniors/domain/chat/service/ChatMessageService.java
@@ -1,5 +1,6 @@
 package com.seniors.domain.chat.service;
 
+import com.seniors.common.exception.type.NotAuthorizedException;
 import com.seniors.domain.chat.dto.ChatMessageDto;
 import com.seniors.domain.chat.entity.ChatMessage;
 import com.seniors.domain.chat.entity.ChatRoom;
@@ -24,7 +25,9 @@ public class ChatMessageService {
 
     @Transactional
     public void saveChatMessage (ChatMessageDto.ChatMessageTransDto chat) {
-        Users users = usersRepository.findById(chat.getUserId()).orElseThrow();
+        Users users = usersRepository.findById(chat.getUserId()).orElseThrow(
+                () -> new NotAuthorizedException("유효하지 않은 회원입니다.")
+        );
         ChatRoom chatRoom = chatRoomRepository.findById(chat.getChatRoomId()).orElseThrow();
         ChatMessage chatMessage = ChatMessage.of(chatRoom, users, chat.getContent());
         chatMessageRepository.save(chatMessage);

--- a/src/main/java/com/seniors/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/seniors/domain/chat/service/ChatRoomService.java
@@ -2,6 +2,7 @@ package com.seniors.domain.chat.service;
 
 import com.seniors.common.dto.CustomPage;
 import com.seniors.common.exception.type.BadRequestException;
+import com.seniors.common.exception.type.NotAuthorizedException;
 import com.seniors.domain.chat.dto.ChatRoomDto;
 import com.seniors.domain.chat.entity.ChatRoom;
 import com.seniors.domain.chat.entity.ChatRoomMembers;
@@ -37,10 +38,14 @@ public class ChatRoomService {
         ChatRoom chatRoom = ChatRoom.builder().build();
         chatRoomRepository.save(chatRoom);
 
-        Users users = usersRepository.findById(senderId).orElseThrow();
+        Users users = usersRepository.findById(senderId).orElseThrow(
+                () -> new NotAuthorizedException("유효하지 않은 회원입니다.")
+        );
         chatRoomMembersRepository.save(ChatRoomMembers.of(chatRoomName, chatRoom, users));
 
-        users = usersRepository.findById(recipientId).orElseThrow();
+        users = usersRepository.findById(recipientId).orElseThrow(
+                () -> new NotAuthorizedException("유효하지 않은 회원입니다.")
+        );
         chatRoomMembersRepository.save(ChatRoomMembers.of(chatRoomName, chatRoom, users));
 
 

--- a/src/main/java/com/seniors/domain/comment/service/CommentService.java
+++ b/src/main/java/com/seniors/domain/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.seniors.domain.comment.service;
 
 import com.seniors.common.exception.type.BadRequestException;
+import com.seniors.common.exception.type.NotAuthorizedException;
 import com.seniors.common.exception.type.NotFoundException;
 import com.seniors.domain.comment.dto.CommentDto.CommentCreateDto;
 import com.seniors.domain.comment.entity.Comment;
@@ -34,7 +35,7 @@ public class CommentService {
                 () -> new NotFoundException("유효하지 않은 게시글입니다.")
         );
         Users users = usersRepository.findById(userId).orElseThrow(
-                () -> new NotFoundException("유효하지 않은 회원입니다.")
+                () -> new NotAuthorizedException("유효하지 않은 회원입니다.")
         );
         Comment savedComment = commentRepository.save(Comment.of(commentReq.getContent(), post, users));
         if (!savedComment.getPost().getUsers().getId().equals(users.getId())) {

--- a/src/main/java/com/seniors/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/seniors/domain/notification/service/NotificationService.java
@@ -137,7 +137,7 @@ public class NotificationService {
 		Sort.Direction direction = Sort.Direction.DESC;
 		Pageable pageable = PageRequest.of(0, size, Sort.by(direction, "id"));
 		Users users =  usersRepository.findById(userDetails.getUserId()).orElseThrow(
-				() -> new NotFoundException("유효하지 않은 회원입니다.")
+				() -> new NotAuthorizedException("유효하지 않은 회원입니다.")
 		);
 		Slice<NotificationDto> results = notificationRepository.findNotificationList(users.getId(), pageable, lastId);
 		return CustomPage.of(results);
@@ -146,7 +146,7 @@ public class NotificationService {
 	@Transactional
 	public void readNotification(CustomUserDetails userDetails, Long id) {
 		Users users = usersRepository.findById(userDetails.getUserId()).orElseThrow(
-				() -> new NotFoundException("유효하지 않은 회원입니다.")
+				() -> new NotAuthorizedException("유효하지 않은 회원입니다.")
 		);
 		Notification notification = notificationRepository.findById(id)
 				.orElseThrow(() -> new NotFoundException("존재하지 않는 알림입니다."));

--- a/src/main/java/com/seniors/domain/post/service/PostService.java
+++ b/src/main/java/com/seniors/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.seniors.domain.post.service;
 
 import com.seniors.common.dto.CustomPage;
 import com.seniors.common.exception.type.BadRequestException;
+import com.seniors.common.exception.type.NotAuthorizedException;
 import com.seniors.common.exception.type.NotFoundException;
 import com.seniors.config.S3Uploader;
 import com.seniors.domain.notification.service.NotificationService;
@@ -59,7 +60,7 @@ public class PostService {
 		}
 
 		Users users = usersRepository.findById(userId).orElseThrow(
-				() -> new NotFoundException("유효하지 않은 회원입니다.")
+				() -> new NotAuthorizedException("유효하지 않은 회원입니다.")
 		);
 		Post post = postRepository.save(Post.of(postCreateDto.getTitle(), postCreateDto.getContent(), users));
 		if (postCreateDto.getFiles() != null && !postCreateDto.getFiles().isEmpty()) {
@@ -125,7 +126,7 @@ public class PostService {
 					() -> new NotFoundException("존재하지 않은 게시글입니다.")
 			);
 			Users users = usersRepository.findById(userId).orElseThrow(
-					() -> new NotFoundException("유효하지 않은 회원입니다.")
+					() -> new NotAuthorizedException("유효하지 않은 회원입니다.")
 			);
 			if (!post.getUsers().getId().equals(users.getId()) && !status) {
 				notificationService.send(post.getUsers(), post, "누군가가 내 피드에 좋아요를 눌렀습니다.");

--- a/src/main/java/com/seniors/domain/resume/service/ResumeService.java
+++ b/src/main/java/com/seniors/domain/resume/service/ResumeService.java
@@ -63,7 +63,7 @@ public class ResumeService {
             throw new BadRequestException(String.join(", ", errorMessages));
         }
         Users user =  usersRepository.findById(userId).orElseThrow(
-                () -> new NotFoundException("유효하지 않은 회원입니다.")
+                () -> new NotAuthorizedException("유효하지 않은 회원입니다.")
         );
 
         if(!resumeReq.getImage().isEmpty()) {
@@ -90,7 +90,7 @@ public class ResumeService {
     @Transactional
     public ResumeDto.GetResumeRes findResume(Long resumeId, Long userId) {
         Users user =  usersRepository.findById(userId).orElseThrow(
-                () -> new NotFoundException("유효하지 않은 회원입니다.")
+                () -> new NotAuthorizedException("유효하지 않은 회원입니다.")
         );
         Resume resume =  resumeRepository.findById(resumeId).orElseThrow(
                 () -> new NotFoundException("이력서가 존재하지 않습니다.")
@@ -104,7 +104,7 @@ public class ResumeService {
     @Transactional
     public DataResponseDto<Slice<ResumeDto.GetResumeByQueryDslRes>> findResumeList(Pageable pageable, Long lastId, Long userId){
         Users user =  usersRepository.findById(userId).orElseThrow(
-                () -> new NotFoundException("유효하지 않은 회원입니다.")
+                () -> new NotAuthorizedException("유효하지 않은 회원입니다.")
         );
         Slice<ResumeDto.GetResumeByQueryDslRes> result = resumeRepository.findResumeList(pageable, lastId, user.getId());
 
@@ -119,7 +119,7 @@ public class ResumeService {
         );
 
         Users user =  usersRepository.findById(userId).orElseThrow(
-                () -> new NotFoundException("유효하지 않은 회원입니다.")
+                () -> new NotAuthorizedException("유효하지 않은 회원입니다.")
         );
 
         if(resume.getUsers().getId()!=user.getId()){
@@ -171,7 +171,7 @@ public class ResumeService {
                 () -> new NotFoundException("이력서가 존재하지 않습니다.")
         );
         Users user =  usersRepository.findById(userId).orElseThrow(
-                () -> new NotFoundException("유효하지 않은 회원입니다.")
+                () -> new NotAuthorizedException("유효하지 않은 회원입니다.")
         );
         if(resume.getUsers().getId()!=user.getId()){
             throw  new NotAuthorizedException("삭제 권한이 없습니다.");


### PR DESCRIPTION
## 📕 제목
유저 Not found -> Unauthorization 에러로 변경 #61

## 📗 작업 내용
유저 Not found -> Unauthorize 에러로 변경으로
API 통신 중 유저 정보가 존재하지 않는 건 로그인이 되어 있지 않은 유저라고 간주하여
401 에러인 Unauthorization 에러로 변경

> 구현 내용 및 작업 했던 내역

- [x] userNotFound 에러를 Unauthorization 으로 변경

## 📘 PR 특이 사항

