### PR TITLE
Fix: 카카오 로그인 검증 파라미터 수정 #84

### DIFF
--- a/src/main/java/com/seniors/config/security/TokenFilter.java
+++ b/src/main/java/com/seniors/config/security/TokenFilter.java
@@ -30,8 +30,8 @@ public class TokenFilter extends OncePerRequestFilter {
 				CustomUserDetails userDetails = tokenService.getUserDetailsByToken(token);
 				securityService.setAuthentication(userDetails);
 			}
-		} catch (Exception e) {
-			throw new NotAuthorizedException("Invalid Token.", e);
+		} catch (Exception err) {
+			throw new NotAuthorizedException("Invalid Token.", err);
 		}
 
 		filterChain.doFilter(request, response);

--- a/src/main/java/com/seniors/config/security/TokenService.java
+++ b/src/main/java/com/seniors/config/security/TokenService.java
@@ -146,7 +146,7 @@ public class TokenService {
 			claims = jwtUtil.getClaimsForReFresh(token);
 		} catch (Exception e) {
 			throw new SignInException(ResultCode.EXPIRED_REFRESH_TOKEN,
-					"Invalid token (" + token + ")");
+					"Invalid token (" + token + ") \n", e);
 		}
 
 		if (claims == null) {

--- a/src/main/java/com/seniors/domain/auth/service/OAuthLoginService.java
+++ b/src/main/java/com/seniors/domain/auth/service/OAuthLoginService.java
@@ -26,7 +26,7 @@ public class OAuthLoginService {
 	}
 
 	private Users findOrCreateUser(OAuthInfoResponse oAuthInfoResponse) {
-		return usersRepository.findByEmail(oAuthInfoResponse.getEmail())
+		return usersRepository.findByNicknameAndSnsId(oAuthInfoResponse.getNickname(), oAuthInfoResponse.getSnsId())
 				.orElseGet(() -> signUp(oAuthInfoResponse));
 	}
 

--- a/src/main/java/com/seniors/domain/comment/entity/Comment.java
+++ b/src/main/java/com/seniors/domain/comment/entity/Comment.java
@@ -1,6 +1,6 @@
 package com.seniors.domain.comment.entity;
 
-import com.seniors.domain.common.BaseEntity;
+import com.seniors.domain.common.BaseTimeEntity;
 import com.seniors.domain.post.entity.Post;
 import com.seniors.domain.users.entity.Users;
 import jakarta.persistence.*;
@@ -18,7 +18,7 @@ import org.hibernate.annotations.Where;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE Comment SET isDeleted = true WHERE id = ?")
 @Where(clause = "isDeleted = false")
-public class Comment extends BaseEntity {
+public class Comment extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/seniors/domain/post/entity/Post.java
+++ b/src/main/java/com/seniors/domain/post/entity/Post.java
@@ -1,14 +1,13 @@
 package com.seniors.domain.post.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.seniors.domain.comment.entity.Comment;
+import com.seniors.domain.common.BaseTimeEntity;
 import com.seniors.domain.users.entity.Users;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import com.seniors.domain.common.BaseEntity;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -23,7 +22,7 @@ import java.util.Set;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Where(clause = "isDeleted = false")
 @SQLDelete(sql = "UPDATE Post SET isDeleted = true WHERE id = ?")
-public class Post extends BaseEntity {
+public class Post extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/seniors/domain/post/entity/PostLike.java
+++ b/src/main/java/com/seniors/domain/post/entity/PostLike.java
@@ -1,14 +1,18 @@
 package com.seniors.domain.post.entity;
 
+import com.seniors.domain.common.BaseTimeEntity;
 import com.seniors.domain.users.entity.Users;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @IdClass(PostLikeEmbedded.class) // Specify the composite primary key class
-public class PostLike {
+public class PostLike extends BaseTimeEntity {
 
     @Id
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/seniors/domain/users/entity/Users.java
+++ b/src/main/java/com/seniors/domain/users/entity/Users.java
@@ -28,13 +28,13 @@ public class Users extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(columnDefinition = "varchar(255) COMMENT 'sns 고유 ID'", unique = true)
+	@Column(columnDefinition = "varchar(255) not null COMMENT 'sns 고유 ID'", unique = true)
 	private String snsId;
 
 	@Column(columnDefinition = "varchar(50) COMMENT '이메일'")
 	private String email;
 
-	@Column(columnDefinition = "varchar(30) COMMENT '닉네임'", unique = true)
+	@Column(columnDefinition = "varchar(30) not null COMMENT '닉네임'", unique = true)
 	private String nickname;
 
 	@Column(columnDefinition = "varchar(10) COMMENT '성별'")

--- a/src/main/java/com/seniors/domain/users/repository/UsersRepository.java
+++ b/src/main/java/com/seniors/domain/users/repository/UsersRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UsersRepository extends JpaRepository<Users, Long>, UsersRepositoryCustom{
-	Optional<Users> findByEmail(String email);
+	Optional<Users> findByNicknameAndSnsId(String nickname, String snsId);
 }


### PR DESCRIPTION
## 📕 제목
카카오 로그인 검증 파라미터 수정 

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

카카오 로그인 시 기존 이메일 검증으로 했으나 이메일은 선택 항목이기에
필수 항목인 닉네임과 로그인 시 얻어오는 snsId로 검증 수정

## 📘 PR 특이 사항

추가적으로 post와 comment, postLike는 BaseEntity가 아닌 BaseTimeEntity로 충분해보여 수정함