### PR TITLE
유저 프로필 이미지 url 응답값 null 처리

### DIFF
--- a/src/main/java/com/seniors/config/security/CustomUserDetails.java
+++ b/src/main/java/com/seniors/config/security/CustomUserDetails.java
@@ -41,7 +41,7 @@ public class CustomUserDetails implements UserDetails {
 
 	@Override
 	public String getUsername() {
-		return userId.toString();
+		return userNickname;
 	}
 
 	@Override
@@ -67,4 +67,5 @@ public class CustomUserDetails implements UserDetails {
 	public void setUserId(Long userId) {
 		this.userId = userId;
 	}
+
 }

--- a/src/main/java/com/seniors/config/security/TokenService.java
+++ b/src/main/java/com/seniors/config/security/TokenService.java
@@ -142,7 +142,6 @@ public class TokenService {
 		String userGender = claims.get("userGender") != null ? claims.get("userGender").toString() : null;
 		String userProfileImageUrl = claims.get("userProfileImageUrl") != null ? claims.get("userProfileImageUrl").toString() : null;
 
-		log.info("profile image: {}", userProfileImageUrl);
 		return new CustomUserDetails(userId, userSnsId, userEmail, userNickname, userGender, userProfileImageUrl);
 	}
 
@@ -166,7 +165,7 @@ public class TokenService {
 		String userNickname = claims.get("userNickname").toString();
 		String userGender = claims.get("userGender") != null ? claims.get("userGender").toString() : null;
 		String userProfileImageUrl = claims.get("userProfileImageUrl") != null ? claims.get("userProfileImageUrl").toString() : null;
-		log.info("profile image: {}", userProfileImageUrl);
+
 		return new CustomUserDetails(userId, userSnsId, userEmail, userNickname, userGender, userProfileImageUrl);
 	}
 

--- a/src/main/java/com/seniors/config/security/TokenService.java
+++ b/src/main/java/com/seniors/config/security/TokenService.java
@@ -67,6 +67,9 @@ public class TokenService {
 		claims.put("userId", user.getId());
 		claims.put("userNickname", user.getNickname());
 		claims.put("userEmail", user.getEmail() != null ? user.getEmail() : null);
+		claims.put("userProfileImageUrl", user.getProfileImageUrl());
+		claims.put("userSnsId", user.getSnsId());
+		claims.put("userGender", user.getGender());
 		claims.put("createdAt",
 				LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")));
 
@@ -78,6 +81,10 @@ public class TokenService {
 		Map<String, Object> claims = new HashMap<>();
 		claims.put("sub", "refresh-token");
 		claims.put("userId", user.getId());
+		claims.put("userProfileImageUrl", user.getProfileImageUrl());
+		claims.put("userSnsId", user.getSnsId());
+		claims.put("userEmail", user.getEmail());
+		claims.put("userGender", user.getGender());
 		claims.put("iat", Timestamp.valueOf(now));
 		claims.put("exp", Timestamp.valueOf(now.plusMinutes(plusExpMinutes)).getTime() / 1000);
 		claims.put("createdAt",
@@ -135,6 +142,7 @@ public class TokenService {
 		String userGender = claims.get("userGender") != null ? claims.get("userGender").toString() : null;
 		String userProfileImageUrl = claims.get("userProfileImageUrl") != null ? claims.get("userProfileImageUrl").toString() : null;
 
+		log.info("profile image: {}", userProfileImageUrl);
 		return new CustomUserDetails(userId, userSnsId, userEmail, userNickname, userGender, userProfileImageUrl);
 	}
 
@@ -153,8 +161,13 @@ public class TokenService {
 		}
 
 		Long userId = Long.parseLong(claims.get("userId").toString());
-
-		return new CustomUserDetails(userId, null, null, null, null, null);
+		String userSnsId = claims.get("userSnsId") != null ? claims.get("userSnsId").toString() : null;
+		String userEmail = claims.get("userEmail") != null ? claims.get("userEmail").toString() : null;
+		String userNickname = claims.get("userNickname").toString();
+		String userGender = claims.get("userGender") != null ? claims.get("userGender").toString() : null;
+		String userProfileImageUrl = claims.get("userProfileImageUrl") != null ? claims.get("userProfileImageUrl").toString() : null;
+		log.info("profile image: {}", userProfileImageUrl);
+		return new CustomUserDetails(userId, userSnsId, userEmail, userNickname, userGender, userProfileImageUrl);
 	}
 
 }


### PR DESCRIPTION
## 📕 제목
유저 프로필 이미지 url 응답값 null 처리

## 📗 작업 내용
유저 정보를 호출 시 profileImageUrl 데이터가 존재하는데에도 url 값이 null로 응답되는 현상 수정
발생된 API 엔드포인트: /api/users/validate

> 구현 내용 및 작업 했던 내역

- [x] TokenService에서 userDetails 내에 profileImageUrl 등 추가 데이터 정의
